### PR TITLE
Adicionada a exportação da interface  CEP

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'cep-promise' {
-  interface CEP {
+  export interface CEP {
     cep: string,
     state: string,
     city: string,


### PR DESCRIPTION
A ideia é ser usada no import, junto com com o typescript, no modelo 
import { CEP } from 'cep-promise'