### PR TITLE
hotfix/validate-proviers

### DIFF
--- a/src/cep-promise.js
+++ b/src/cep-promise.js
@@ -56,8 +56,6 @@ function validateProviders (providers) {
         ]
       })
     }
-
-    return provider
   }
 }
 


### PR DESCRIPTION
A atual implementação está validando apenas o primeiro provider do array de providers passado por parâmetro. Removendo o return, todos os providers serão validados.