### PR TITLE
[TS] Altera declaração de exportação para melhorar utilização pela compilação em typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,5 +13,5 @@ declare module 'cep-promise' {
 
   function cep( cep: string | number ): Promise<CEP>
 
-  export = cep
+  export default cep
 }


### PR DESCRIPTION
export estava com problemas em projetos com compilação typescript, exportando por default corrige esse problema.