### PR TITLE
Correções typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,9 +8,6 @@ declare module 'cep-promise' {
     service: string
   }
 
-  // this workarround is because this : https://github.com/Microsoft/TypeScript/issues/5073
-  namespace cep {}
-
   type AvaliableProviders =
     "brasilapi" |
     "correios" |

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare module 'cep-promise' {
     timeout?: number
   }
 
-  export function cep(cep: string | number, configurations: Configurations): Promise<CEP>
+  function cep(cep: string | number, configurations: Configurations): Promise<CEP>
 
   export default cep
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare module 'cep-promise' {
     timeout?: number
   }
 
-  function cep(cep: string | number, configurations: Configurations): Promise<CEP>
+  function cep(cep: string | number, configurations?: Configurations): Promise<CEP>
 
   export default cep
 }


### PR DESCRIPTION
Corrige importações do cep-promise utilizando typescript (https://github.com/BrasilAPI/cep-promise/issues/212).

- O workarround do namespace não é mais necessário, devendo ser utilizada a opção de esModuleInterop:
#### **`tsconfig.json`**
```json
{
  "compilerOptions": {
    "esModuleInterop": true
  }
}
```
- O export nomeado estava incorreto, pois não é possível fazer ```import {  cep } from 'cep-promise'```.
- Torna parâmetro `configurations` opcional.