### PR TITLE
Alteração no endereço público da apicep.com

### DIFF
--- a/src/services/widenet.js
+++ b/src/services/widenet.js
@@ -4,12 +4,13 @@ import fetch from 'node-fetch'
 import ServiceError from '../errors/service.js'
 
 export default function fetchWideNetService(cepWithLeftPad, configurations) {
-  const url = `https://ws.apicep.com/busca-cep/api/cep/${cepWithLeftPad}.json`
+  const cepWithDash = `${cepWithLeftPad.slice(0, 5)}-${cepWithLeftPad.slice(5)}`
+  const url = `https://cdn.apicep.com/file/apicep/${cepWithDash}.json`
   const options = {
     method: 'GET',
     mode: 'cors',
     headers: {
-      'content-type': 'application/json;charset=utf-8'
+      accept: 'application/json'
     },
     timeout: configurations.timeout || 30000
   }


### PR DESCRIPTION
Minha primeira contribuição aqui, não sei se tem algum padrão, mas segue a proposta de mudança

Estamos fechando o acesso público ao ws.apicep.com e pra não deixar a comunidade sem acesso, criamos uma alternativa que oferece exatamente os mesmos dados, mas baseado em um CDN de arquivos estáticos em um S3, atualizados de forma assíncrona.

Nossa proposta pro webservice antigo era buscar os dados do CEP em tempo real caso ele esteja desatualizado ou não exista em nossa base, porém devido ao volume gigantesco de pesquisas de CEPs inválidos (tentativas de dump forçado, scraping, etc) nossa fila de atualizações ficava quase sempre prejudicada, mesmo com restrições de flood e etc.

O acesso público novo não tem limite de consulta e não tem restrição cors. Exemplo do novo endereço:
https://cdn.apicep.com/file/apicep/64009-140.json

Fico à disposição