### PR TITLE
AvailableProviders declaration from 'enum' to 'type'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,13 +8,7 @@ declare module 'cep-promise' {
     service: string
   }
 
-  export enum AvailableProviders {
-    brasilapi = "brasilapi",
-    correios = "correios",
-    correiosAlt = "correios-alt",
-    viacep = "viacep",
-    widenet = "widenet"
-  }
+  export type AvailableProviders = "brasilapi" | "correios" |  "correios-alt" | "viacep" | "widenet"
 
 
   export interface Configurations {


### PR DESCRIPTION
Bom dia pessoal,

### Sugestão
Sugiro uma simples alteração no `index.d.ts` para substituir a declaração de `AvailableProviders` de ENUM para TYPE.

### Motivo
Estava usando a API e reparei que o enum `AvailableProviders` estava `undefined`, o que causava um erro ao usar o enum para definir a lista de provedores:

![image](https://github.com/BrasilAPI/cep-promise/assets/68154538/08655197-718f-4a72-8989-56ae5d0766f6)

```
TypeError: Cannot read properties of undefined (reading 'brasilapi')
```

</br>

A alternativa é passar os provedores como uma lista de strings. O problema é que o TS também acusa erro por entender que a string não é do tipo do enum:

![image](https://github.com/BrasilAPI/cep-promise/assets/68154538/aa8034b2-3eb5-4436-ace3-9467258789df)

</br>

É possível contornar o erro tipando o objeto de configuração ou a lista de provedores:

![image](https://github.com/BrasilAPI/cep-promise/assets/68154538/e4ae636d-38b8-457d-8f99-b1acb4a01b36)

![image](https://github.com/BrasilAPI/cep-promise/assets/68154538/075030ac-77d6-45d2-b893-217e5d2d7409)

</br>

Porém, acredito que seria melhor alterar a declaração de `AvailableProviders` de ENUM para TYPE, o que possibilita passar a lista de provedores como string sem nenhum erro e sem nenhum import adicional (e com a vantagem adicional do intellisense):

![image](https://github.com/BrasilAPI/cep-promise/assets/68154538/31c98782-c098-415c-bf54-125feffc4550)

</br>
</br>

referências:
https://lukasbehal.com/2017-05-22-enums-in-declaration-files/
https://stackoverflow.com/questions/62109542/enums-in-typescript-d-ts-file

