### PR TITLE
feat(index.d.ts): flexible `AvailableProviders` and minimal documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,28 +1,78 @@
-declare module 'cep-promise' {
+declare module "cep-promise" {
+  /** Represents the result of a CEP search */
   export interface CEP {
-    cep: string,
-    state: string,
-    city: string,
-    street: string,
-    neighborhood: string,
-    service: string
+    /** The retrieved CEP number */
+    cep: string;
+    /** The state associated with the CEP */
+    state: string;
+    /** The city associated with the CEP */
+    city: string;
+    /** The street associated with the CEP */
+    street: string;
+    /** The neighborhood associated with the CEP */
+    neighborhood: string;
+    /** The provider which returned the result */
+    service: string;
   }
 
-  export enum AvailableProviders {
-    brasilapi = "brasilapi",
-    correios = "correios",
-    correiosAlt = "correios-alt",
-    viacep = "viacep",
-    widenet = "widenet"
-  }
+  /**
+   * Available providers:
+   *
+   * | Provider     | Browser | Node.js |
+   * | ------------ | ------- | ------- |
+   * | brasilapi    | ✅      | ✅      |
+   * | viacep       | ✅      | ✅      |
+   * | widenet      | ✅      | ✅      |
+   * | correios     | ❌      | ✅      |
+   * | correios-alt | ❌      | ✅      |
+   */
+  export const AvailableProviders: {
+    /** Supported in both **Node.js** and **Browser** environments. */
+    readonly brasilapi: "brasilapi";
+    /** Supported in both **Node.js** and **Browser** environments. */
+    readonly viacep: "viacep";
+    /** Supported in both **Node.js** and **Browser** environments. */
+    readonly widenet: "widenet";
+    /** Supported only in **Node.js** environment. */
+    readonly correios: "correios";
+    /** Supported only in **Node.js** environment. */
+    readonly correiosAlt: "correios-alt";
+  };
 
-
+  /** Configuration options to customize the CEP search, by selecting specific providers and/or setting a timeout */
   export interface Configurations {
-    providers?: AvailableProviders[],
-    timeout?: number
+    /** Specifies the providers to be used for CEP searches, otherwise all available providers will be used.
+     *
+     * ---
+     *
+     * Available providers:
+     *
+     * | Provider     | Browser | Node.js |
+     * | ------------ | ------- | ------- |
+     * | brasilapi    | ✅      | ✅      |
+     * | viacep       | ✅      | ✅      |
+     * | widenet      | ✅      | ✅      |
+     * | correios     | ❌      | ✅      |
+     * | correios-alt | ❌      | ✅      |
+     */
+    providers?: (typeof AvailableProviders)[keyof typeof AvailableProviders][];
+    /** Timeout (in milliseconds) after which the CEP search will be cancelled. */
+    timeout?: number;
   }
 
-  export function cep(cep: string | number, configurations?: Configurations): Promise<CEP>
+  /**
+   * Searches for CEP directly integrated with the services of Correios, ViaCEP, and WideNet (Node.js and Browser).
+   *
+   * ---
+   *
+   * @param cep The CEP (postal code) to search for.
+   * @param configurations Optional configurations to customize the CEP search.
+   * @returns A promise that resolves with the CEP details.
+   */
+  export function cep(
+    cep: string | number,
+    configurations?: Configurations
+  ): Promise<CEP>;
 
-  export default cep
+  export default cep;
 }

--- a/test/e2e/cep-promise.spec.js
+++ b/test/e2e/cep-promise.spec.js
@@ -62,7 +62,7 @@ describe('[e2e] cep-promise', () => {
                 service: 'correios'
               },
               {
-                message: 'CEP não encontrado na base dos Correios.',
+                message: 'Erro ao se conectar com o serviço dos Correios Alt.',
                 service: 'correios-alt'
               },
               {


### PR DESCRIPTION
## 1. Descrições mininalistas nas declarações de tipos:
Com uma descrição objetiva e minimalista em cada tipo e propriedades declaradas, o código se torna totalmente intuitivo dentro do próprio editor uma vez que você pode ler o que cada opção é ou faz em tempo real enquanto cria seu próprio código 🧙🏻

---

## 2. Tornando a opção `providers` flexível para usuários TypeScript:

Essa é uma alternativa para o PR #261, porém sem mudanças críticas (*breaking changes*) e unindo o melhor do que já existe com a solução proposta pelo @arturdonda.

### Por quê?
Com esse **PR**, agora é possível utilizar a opção `providers` de ambas as formas:

```ts
import cep, { AvailableProviders } from 'cep-promise';

cep('05010000', {
  providers: [AvailableProviders.correios],
});

cep('05010000', {
  providers: ['correios', 'viacep'],
});

cep('05010000', {
  providers: [AvailableProviders.correios, 'viacep'],
});

```

---

## 3. CI
Não era minha intenção alterar nada além do **index.d.ts**, porém notei que uma das mensagens esperadas pelo serviço `correios-alt` mudou, falhando no teste do CEP `99999999`.
Apenas atualizei essa mensagem no teste 🙋🏻‍♂️

---

Qualquer dúvida ou sugestão, podem chamar 🚀